### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/Davidryan316/d59ad436-c146-452f-8e5b-2fe7fbefeb8c/19e71af6-c59a-4950-abdc-dcbd9c38b0ec/_apis/work/boardbadge/0e794bda-e4e7-49b6-aa35-c7706e67a492)](https://dev.azure.com/Davidryan316/d59ad436-c146-452f-8e5b-2fe7fbefeb8c/_boards/board/t/19e71af6-c59a-4950-abdc-dcbd9c38b0ec/Microsoft.RequirementCategory)
 # CA1-DevOps-Pipelines


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/Davidryan316/d59ad436-c146-452f-8e5b-2fe7fbefeb8c/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.